### PR TITLE
Fix up network flow and better integrate DNS fallback mechanism.

### DIFF
--- a/roku_remote/roku_remote.py
+++ b/roku_remote/roku_remote.py
@@ -6,10 +6,14 @@ from contextlib import closing
 from threading import Thread
 from urllib.parse import urlencode
 from urllib.request import urlopen
+from socket import gethostbyname, inet_aton
 
 
 class RokuRemote:
     def __init__(self, master):
+        self.cached_ip = None
+        self.last_ip_lookup = None
+        self.netloc = None
         self.master = master
         master.title('ROKU REMOTE')
         master.configure(bg='#F2F2F2')
@@ -108,7 +112,15 @@ class RokuRemote:
 
     def make_request(self, btn_cmd):
         ip = self.server_ip_addr.get('1.0', END).strip()
-        url = 'http://' + ip + ':8060/keypress/' + btn_cmd
+        try:
+            inet_aton(ip)
+            self.netloc = ip
+        except OSError:
+            if not self.cached_ip or self.last_ip_lookup != ip:
+                self.last_ip_lookup = ip
+                self.cached_ip = gethostbyname(ip)
+                self.netloc = self.cached_ip
+        url = 'http://' + self.netloc + ':8060/keypress/' + btn_cmd
         try:
             with closing(urlopen(url, urlencode('').encode())) as resp:
                 resp.read().decode()


### PR DESCRIPTION
Here's a rework of `make_request` that makes the codepaths less divergent and improves the messaging/debug output, and should significantly improve the reliability of network comms in general. This is a follow-up to #2.

Here, we've simplified to just call `socket.getaddrinfo` regardless of the type of input, since that method not only accepts both IPs or hostnames without issue, but it also handles IPv6 and AAAA records. I removed the caching mechanism from #2 because I don't think it really does much for us in this context (local OS DNS cache should work fine with `getaddrinfo`) and would take some effort to thoroughly test and debug.

I tested this with variety of different addresses: some valid internal Roku addresses, some public domains, some invalid IPs, and some internal IPs that don't have a Roku running. Here's the log of my tests:

```
DEBUG: addrlog: Input 'r' not a recognized network address.
DEBUG: addrlog: Not sending request.
DEBUG: addrlog: Exception details: [Errno -2] Name or service not known
DEBUG: addrlog: ----- end make_request: took 0.86s  -----
DEBUG: addrlog: send btn_cmd select to addr rbad
DEBUG: addrlog: Input 'rbad' not a recognized network address.
DEBUG: addrlog: Not sending request.
DEBUG: addrlog: Exception details: [Errno -2] Name or service not known
DEBUG: addrlog: ----- end make_request: took 1.50s  -----
DEBUG: addrlog: send btn_cmd select to addr 192.168.0.1
DEBUG: addrlog: urlopen http://192.168.0.1:8060/keypress/select failed..
DEBUG: addrlog: Ensure Roku at 192.168.0.1 is available.
DEBUG: addrlog: Exception details: <urlopen error timed out>
DEBUG: addrlog: ----- end make_request: took 5.01s  -----
DEBUG: addrlog: send btn_cmd select to addr roku-ultra
DEBUG: addrlog: ----- end make_request: took 0.06s  -----
DEBUG: addrlog: send btn_cmd select to addr roku4
DEBUG: addrlog: ----- end make_request: took 0.48s  -----
DEBUG: addrlog: send btn_cmd select to addr 192.168.0.1
DEBUG: addrlog: urlopen http://192.168.0.1:8060/keypress/select failed..
DEBUG: addrlog: Ensure Roku at 192.168.0.1 is available.
DEBUG: addrlog: Exception details: <urlopen error [Errno 111] Connection refused>
DEBUG: addrlog: ----- end make_request: took 0.00s  -----
DEBUG: addrlog: send btn_cmd select to addr 192.168.0.212
DEBUG: addrlog: ----- end make_request: took 0.05s  -----
DEBUG: addrlog: send btn_cmd select to addr 192.168.0.212
DEBUG: addrlog: ----- end make_request: took 0.05s  -----
DEBUG: addrlog: send btn_cmd select to addr github.com
DEBUG: addrlog: urlopen http://140.82.114.3:8060/keypress/select failed..
DEBUG: addrlog: Ensure Roku at github.com is available.
DEBUG: addrlog: Exception details: <urlopen error timed out>
DEBUG: addrlog: ----- end make_request: took 5.05s  -----
DEBUG: addrlog: send btn_cmd select to addr github.com
DEBUG: addrlog: urlopen http://140.82.114.3:8060/keypress/select failed..
DEBUG: addrlog: Ensure Roku at github.com is available.
DEBUG: addrlog: Exception details: <urlopen error timed out>
DEBUG: addrlog: ----- end make_request: took 5.04s  -----
DEBUG: addrlog: send btn_cmd select to addr roku4
DEBUG: addrlog: ----- end make_request: took 0.05s  -----
DEBUG: addrlog: send btn_cmd select to addr 192.168.0.1
DEBUG: addrlog: urlopen http://192.168.0.1:8060/keypress/select failed..
DEBUG: addrlog: Ensure Roku at 192.168.0.1 is available.
DEBUG: addrlog: Exception details: <urlopen error [Errno 111] Connection refused>
DEBUG: addrlog: ----- end make_request: took 0.00s  -----
DEBUG: addrlog: send btn_cmd select to addr 288.899.99.99
DEBUG: addrlog: Input '288.899.99.99' not a recognized network address.
DEBUG: addrlog: Not sending request.
DEBUG: addrlog: Exception details: [Errno -2] Name or service not known
DEBUG: addrlog: ----- end make_request: took 0.29s  -----
DEBUG: addrlog: send btn_cmd select to addr example.com
DEBUG: addrlog: urlopen http://93.184.216.34:8060/keypress/select failed..
DEBUG: addrlog: Ensure Roku at example.com is available.
DEBUG: addrlog: Exception details: <urlopen error timed out>
DEBUG: addrlog: ----- end make_request: took 5.04s  -----
DEBUG: addrlog: send btn_cmd select to addr localfake
DEBUG: addrlog: Input 'localfake' not a recognized network address.
DEBUG: addrlog: Not sending request.
DEBUG: addrlog: Exception details: [Errno -2] Name or service not known
DEBUG: addrlog: ----- end make_request: took 1.44s  -----
DEBUG: addrlog: send btn_cmd select to addr roku4
DEBUG: addrlog: ----- end make_request: took 0.05s  -----
```

I set a 5-second timeout since Roku intends to reject any non-LAN traffic anyway, and figured a 5-second lag time on a remote is about the limit of plausible usage anyway. The one thing I noticed while testing is that if you hit "POWER", the program never receives an ack and times out. It should either assume the message was delivered without waiting or the call should be fixed to make sure we receive and process any response that the Roku may send (haven't checked whether it actually sends one or not).

The debug stuff in the code is still in this PR, giving visibility into the methods, so you'll probably want to remove and/or tweak it before merging. Of course, in a larger project we'd integrate a log framework, etc. etc., but this is a single script for a quick thing, so don't want to overcomplicate it. :)

I don't expect to spend much more time on this since it's working well for my purposes right now, but please let me know if you have questions. 👍 